### PR TITLE
Check for `AxProtector_*` files instead of `.wbc`

### DIFF
--- a/.build/BuildToolkit.ps1
+++ b/.build/BuildToolkit.ps1
@@ -245,10 +245,15 @@ function Invoke-Licensing($SearchPath = $RootPath) {
                 Invoke-ProtectDotNet8 -csprojItem $csprojItem -licenseCreationDate $licenseCreationDate -projectName $projectName -assemlbies $assemlbies
             } else {
 	            # Pre .NET 8 (MORYX 6)
-	            $licensingConfig = [System.IO.Path]::ChangeExtension($CsprojItem.FullName, ".wbc")
+                $projectName = ([System.IO.Path]::GetFileNameWithoutExtension($CsprojItem.Name));
+                $licensingConfig = [System.IO.Path]::Combine($CsprojItem.DirectoryName, "AxProtector_$projectName.xml");
 	            if(Test-Path $licensingConfig) {
 	                Invoke-ProtectPreDotNet8 -csprojItem $csprojItem -licenseCreationDate $licenseCreationDate -projectName $projectName -assemlbies $assemlbies
 	            }     
+                else {
+                    Write-Host-Error "No configuration found to protect assemblies."
+                    exit 1;
+                }
 			}
         } else {
             Write-Host-Warning "Skipping $projectName"
@@ -497,10 +502,11 @@ function ShouldCreatePackage($csprojItem){
 function IsLicensedProject($CsprojItem){
     $licensingConfig = [System.IO.Path]::Combine($CsprojItem.DirectoryName, "protect.WibuCpsConf");
 
-    # Fallback for MORYX 6 most configs were stored as `<project>.wbc`
-    $wbcFile = [System.IO.Path]::ChangeExtension($CsprojItem.FullName, ".wbc")
+    # Fallback for MORYX 6 most configs were stored as `AxProtector_<project>.xml`
+    $projectName = ([System.IO.Path]::GetFileNameWithoutExtension($CsprojItem.Name));
+    $axProtectorFile = [System.IO.Path]::Combine($CsprojItem.DirectoryName, "AxProtector_$projectName.xml");
 
-    return (Test-Path $licensingConfig) -or (Test-Path $wbcFile)
+    return (Test-Path $licensingConfig) -or (Test-Path $axProtectorFile)
 }
 
 function CreateFolderIfNotExists([string]$Folder) {


### PR DESCRIPTION
Some projects don't contain a `.wbc` file in the required format. But they usually contain a `AxProtector_<project>.xml` which acts as a requirement now in MORYX 6 projects for determining if a project should be protected by a license.

If it doesn't exist, the licensing procedure would exit with an error code, in order to fail the pipeline.